### PR TITLE
[User] : membership 정보 feign 요청 및 redis에서 삭제 기능 추가

### DIFF
--- a/user-service/build.gradle
+++ b/user-service/build.gradle
@@ -33,9 +33,7 @@ dependencies {
 
     // Spring Boot
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
-    implementation 'org.springframework.boot:spring-boot-starter-cache'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-mail'

--- a/user-service/src/main/java/com/boeingmerryho/business/userservice/UserServiceApplication.java
+++ b/user-service/src/main/java/com/boeingmerryho/business/userservice/UserServiceApplication.java
@@ -2,7 +2,11 @@ package com.boeingmerryho.business.userservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
+@EnableFeignClients
+@EnableDiscoveryClient
 @SpringBootApplication
 public class UserServiceApplication {
 

--- a/user-service/src/main/java/com/boeingmerryho/business/userservice/application/UserHelper.java
+++ b/user-service/src/main/java/com/boeingmerryho/business/userservice/application/UserHelper.java
@@ -78,5 +78,7 @@ public interface UserHelper {
 	void removeVerificationCode(String email);
 
 	void checkDuplicatedVerificationRequest(String email);
+
+	String getNotifyLoginResponse(Long id);
 }
 

--- a/user-service/src/main/java/com/boeingmerryho/business/userservice/application/UserHelper.java
+++ b/user-service/src/main/java/com/boeingmerryho/business/userservice/application/UserHelper.java
@@ -80,5 +80,7 @@ public interface UserHelper {
 	void checkDuplicatedVerificationRequest(String email);
 
 	String getNotifyLoginResponse(Long id);
+
+	void removeUserMembershipInfoFromRedis(Long id);
 }
 

--- a/user-service/src/main/java/com/boeingmerryho/business/userservice/application/dto/request/feign/LoginSuccessRequest.java
+++ b/user-service/src/main/java/com/boeingmerryho/business/userservice/application/dto/request/feign/LoginSuccessRequest.java
@@ -1,0 +1,6 @@
+package com.boeingmerryho.business.userservice.application.dto.request.feign;
+
+public record LoginSuccessRequest(
+	Long userId
+) {
+}

--- a/user-service/src/main/java/com/boeingmerryho/business/userservice/application/feign/MembershipClient.java
+++ b/user-service/src/main/java/com/boeingmerryho/business/userservice/application/feign/MembershipClient.java
@@ -1,0 +1,18 @@
+package com.boeingmerryho.business.userservice.application.feign;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import com.boeingmerryho.business.userservice.application.dto.request.feign.LoginSuccessRequest;
+
+@FeignClient(name = "membership-service")
+public interface MembershipClient {
+
+	@PostMapping("/membership/user/login")
+	ResponseEntity<String> notifyLogin(@RequestBody LoginSuccessRequest request);
+
+}

--- a/user-service/src/main/java/com/boeingmerryho/business/userservice/application/service/UserAdminService.java
+++ b/user-service/src/main/java/com/boeingmerryho/business/userservice/application/service/UserAdminService.java
@@ -165,6 +165,9 @@ public class UserAdminService {
 			tokenMap.get("accessToken"),
 			tokenMap.get("refreshToken")
 		);
+
+		userHelper.getNotifyLoginResponse(user.getId());
+		
 		return userApplicationMapper.toUserLoginResponseDto(serviceDto);
 	}
 

--- a/user-service/src/main/java/com/boeingmerryho/business/userservice/application/service/UserAdminService.java
+++ b/user-service/src/main/java/com/boeingmerryho/business/userservice/application/service/UserAdminService.java
@@ -154,6 +154,7 @@ public class UserAdminService {
 		userHelper.blacklistToken(accessToken);
 
 		userHelper.deleteKeyFromRedis(result.tokenKey());
+		//todo: redis에 있는 사용자-멤버십 정보 삭제
 	}
 
 	public UserLoginResponseDto loginUserAdmin(UserAdminLoginRequestServiceDto dto) {
@@ -167,7 +168,7 @@ public class UserAdminService {
 		);
 
 		userHelper.getNotifyLoginResponse(user.getId());
-		
+
 		return userApplicationMapper.toUserLoginResponseDto(serviceDto);
 	}
 

--- a/user-service/src/main/java/com/boeingmerryho/business/userservice/application/service/UserAdminService.java
+++ b/user-service/src/main/java/com/boeingmerryho/business/userservice/application/service/UserAdminService.java
@@ -154,7 +154,8 @@ public class UserAdminService {
 		userHelper.blacklistToken(accessToken);
 
 		userHelper.deleteKeyFromRedis(result.tokenKey());
-		//todo: redis에 있는 사용자-멤버십 정보 삭제
+
+		userHelper.removeUserMembershipInfoFromRedis(userId);
 	}
 
 	public UserLoginResponseDto loginUserAdmin(UserAdminLoginRequestServiceDto dto) {

--- a/user-service/src/main/java/com/boeingmerryho/business/userservice/application/service/UserService.java
+++ b/user-service/src/main/java/com/boeingmerryho/business/userservice/application/service/UserService.java
@@ -87,6 +87,7 @@ public class UserService {
 		userHelper.blacklistToken(accessToken);
 
 		userHelper.deleteKeyFromRedis(result.tokenKey());
+		//todo: redis에 있는 사용자-멤버십 정보 삭제
 	}
 
 	@Transactional(readOnly = true)

--- a/user-service/src/main/java/com/boeingmerryho/business/userservice/application/service/UserService.java
+++ b/user-service/src/main/java/com/boeingmerryho/business/userservice/application/service/UserService.java
@@ -73,6 +73,9 @@ public class UserService {
 			tokenMap.get("accessToken"),
 			tokenMap.get("refreshToken")
 		);
+
+		userHelper.getNotifyLoginResponse(user.getId());
+
 		return userApplicationMapper.toUserLoginResponseDto(serviceDto);
 	}
 

--- a/user-service/src/main/java/com/boeingmerryho/business/userservice/application/service/UserService.java
+++ b/user-service/src/main/java/com/boeingmerryho/business/userservice/application/service/UserService.java
@@ -87,7 +87,8 @@ public class UserService {
 		userHelper.blacklistToken(accessToken);
 
 		userHelper.deleteKeyFromRedis(result.tokenKey());
-		//todo: redis에 있는 사용자-멤버십 정보 삭제
+		
+		userHelper.removeUserMembershipInfoFromRedis(userId);
 	}
 
 	@Transactional(readOnly = true)

--- a/user-service/src/main/java/com/boeingmerryho/business/userservice/exception/ErrorCode.java
+++ b/user-service/src/main/java/com/boeingmerryho/business/userservice/exception/ErrorCode.java
@@ -40,6 +40,8 @@ public enum ErrorCode implements BaseErrorCode {
 
 	EMAIL_SEND_FAILED("U-028", "인증 코드를 위한 이메일 발송에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
 
+	MEMBERSHIP_INFO_SETTING_FAIL("U-029", "멤버십 정보를 저장하는데 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+	MEMBERSHIP_FEIGN_REQUEST_FAIL("U-030", "Membership service feign요청에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
 	;
 
 	private final String errorCode;

--- a/user-service/src/main/java/com/boeingmerryho/business/userservice/infrastructure/UserHelperImpl.java
+++ b/user-service/src/main/java/com/boeingmerryho/business/userservice/infrastructure/UserHelperImpl.java
@@ -40,6 +40,7 @@ public class UserHelperImpl implements UserHelper {
 	private static final String USER_TOKEN_PREFIX = "user:token:";
 	private static final String BLACKLIST_PREFIX = "blacklist:";
 	private static final String VERIFICATION_PREFIX = "verification:email:";
+	private static final String MEMBERSHIP_INFO_PREFIX = "user:membership:info:";
 
 	private final RedisTemplate<String, Object> redisTemplate;
 	private final JwtTokenProvider jwtTokenProvider;
@@ -246,6 +247,11 @@ public class UserHelperImpl implements UserHelper {
 		} catch (Exception e) {
 			throw new GlobalException(ErrorCode.MEMBERSHIP_FEIGN_REQUEST_FAIL);
 		}
+	}
+
+	public void removeUserMembershipInfoFromRedis(Long id) {
+		String membershipKey = MEMBERSHIP_INFO_PREFIX+id;
+		redisTemplate.delete(membershipKey);
 	}
 
 }

--- a/user-service/src/main/java/com/boeingmerryho/business/userservice/infrastructure/UserHelperImpl.java
+++ b/user-service/src/main/java/com/boeingmerryho/business/userservice/infrastructure/UserHelperImpl.java
@@ -24,6 +24,7 @@ import com.boeingmerryho.business.userservice.domain.UserRoleType;
 import com.boeingmerryho.business.userservice.domain.repository.UserRepository;
 import com.boeingmerryho.business.userservice.exception.ErrorCode;
 
+import feign.FeignException;
 import io.github.boeingmerryho.commonlibrary.exception.GlobalException;
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
@@ -235,14 +236,16 @@ public class UserHelperImpl implements UserHelper {
 		}
 	}
 
-	public String getNotifyLoginResponse(Long id){
+	public String getNotifyLoginResponse(Long id) {
 		LoginSuccessRequest request = new LoginSuccessRequest(id);
 		try {
 			ResponseEntity<String> response = membershipClient.notifyLogin(request);
-			if (response.getStatusCode().is2xxSuccessful()) {
-				return response.getBody();
-			} else {
+			return response.getBody();
+		} catch (FeignException e) {
+			if (e.status() >= 400 && e.status() < 500) {
 				throw new GlobalException(ErrorCode.MEMBERSHIP_INFO_SETTING_FAIL);
+			} else {
+				throw new GlobalException(ErrorCode.MEMBERSHIP_FEIGN_REQUEST_FAIL);
 			}
 		} catch (Exception e) {
 			throw new GlobalException(ErrorCode.MEMBERSHIP_FEIGN_REQUEST_FAIL);

--- a/user-service/src/test/java/com/boeingmerryho/business/userservice/infrastructure/UserHelperImplLoginTest.java
+++ b/user-service/src/test/java/com/boeingmerryho/business/userservice/infrastructure/UserHelperImplLoginTest.java
@@ -1,0 +1,79 @@
+package com.boeingmerryho.business.userservice.infrastructure;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.annotation.Description;
+import org.springframework.http.ResponseEntity;
+
+import com.boeingmerryho.business.userservice.application.dto.request.feign.LoginSuccessRequest;
+import com.boeingmerryho.business.userservice.application.feign.MembershipClient;
+import com.boeingmerryho.business.userservice.exception.ErrorCode;
+
+import feign.FeignException;
+import feign.Request;
+import io.github.boeingmerryho.commonlibrary.exception.GlobalException;
+
+@ExtendWith(MockitoExtension.class)
+class UserHelperImplTest {
+
+	@InjectMocks
+	private UserHelperImpl userHelper;
+
+	@Mock
+	private MembershipClient membershipClient;
+
+	@Test
+	@Description("로그인 성공 시 정상적으로 응답을 반환한다")
+	void should_return_response_when_login_successful() {
+		Long userId = 1L;
+		when(membershipClient.notifyLogin(any()))
+			.thenReturn(ResponseEntity.ok("success"));
+
+		String result = userHelper.getNotifyLoginResponse(userId);
+
+		assertEquals("success", result);
+	}
+
+	@Test
+	@Description("로그인 요청 응답이 400일 경우 MEMBERSHIP_INFO_SETTING_FAIL 예외 발생")
+	void should_throw_MEMBERSHIP_INFO_SETTING_FAIL_when_login_request_returns_400() {
+		Long userId = 1L;
+
+		FeignException feignException = new FeignException.BadRequest(
+			"Bad Request",
+			Request.create(Request.HttpMethod.POST, "/membership/user/login", Map.of(), null, null, null),
+			null, null
+		);
+
+		when(membershipClient.notifyLogin(any(LoginSuccessRequest.class)))
+			.thenThrow(feignException);
+
+		GlobalException exception = assertThrows(GlobalException.class, () -> {
+			userHelper.getNotifyLoginResponse(userId);
+		});
+
+		assertEquals(ErrorCode.MEMBERSHIP_INFO_SETTING_FAIL, exception.getErrorCode());
+	}
+
+	@Test
+	@Description("로그인 요청 중 예외 발생시 MEMBERSHIP_FEIGN_REQUEST_FAIL 예외 발생")
+	void should_throw_MEMBERSHIP_FEIGN_REQUEST_FAIL_when_exception_occurs_during_login_request() {
+		Long userId = 1L;
+		when(membershipClient.notifyLogin(any()))
+			.thenThrow(new RuntimeException("Feign client failure"));
+
+		GlobalException exception = assertThrows(GlobalException.class, () -> {
+			userHelper.getNotifyLoginResponse(userId);
+		});
+
+		assertEquals(ErrorCode.MEMBERSHIP_FEIGN_REQUEST_FAIL, exception.getErrorCode());
+	}
+}


### PR DESCRIPTION
## PR Type
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Summary : 변경 내용
- **as-is**
  - feign 클라이언트 미구현
  - feign 응답에서 MEMBERSHIP_INFO_SETTING_FAIL 응답 처리 불가

- **to-be**
  - feign client 구현
  - login 메서드에서 사용할 user helper에 feign 요청 메서드 구현
  - logout 메서드에서 사용할 user helper에 redis에서 삭제 메서드 구현
  - feign 응답에서 MEMBERSHIP_INFO_SETTING_FAIL 응답 처리 가능하도록 try 범위 수정

## Issue Number
- close #87
- close #90 

## Etc

MEMBERSHIP_INFO_PREFIX 를 user:membership:info: 로 가정
