### PR TITLE
[Membership] userId 권한 확인

### DIFF
--- a/membership-service/build.gradle
+++ b/membership-service/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 
     // common
-    implementation 'io.github.boeingmerryho:common-library:1.0.4'
+    implementation 'io.github.boeingmerryho:common-library:1.1.2'
 
     // querydsl
     implementation "com.querydsl:querydsl-jpa:${querydslVersion}:jakarta"

--- a/membership-service/src/main/java/com/boeingmerryho/business/membershipservice/infrastructure/client/PaymentFeignClient.java
+++ b/membership-service/src/main/java/com/boeingmerryho/business/membershipservice/infrastructure/client/PaymentFeignClient.java
@@ -9,6 +9,6 @@ import com.boeingmerryho.business.membershipservice.presentation.dto.response.Pa
 
 @FeignClient(name = "payment-service")
 public interface PaymentFeignClient {
-	@PostMapping("/payments/create")
+	@PostMapping("/payment-service/payments/create")
 	PaymentCreationResponseDto createPayment(@RequestBody PaymentRequestDto dto);
 }

--- a/membership-service/src/main/java/com/boeingmerryho/business/membershipservice/infrastructure/config/auth/RedisUserInfoProvider.java
+++ b/membership-service/src/main/java/com/boeingmerryho/business/membershipservice/infrastructure/config/auth/RedisUserInfoProvider.java
@@ -1,0 +1,29 @@
+package com.boeingmerryho.business.membershipservice.infrastructure.config.auth;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import io.github.boeingmerryho.commonlibrary.interceptor.UserInfoProvider;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class RedisUserInfoProvider implements UserInfoProvider {
+
+	private final RedisTemplate<String, Object> redisTemplate;
+
+	@Override
+	public Map<String, Object> getUserInfo(long userId) {
+		String key = "user:info:" + userId;
+		Map<Object, Object> entries = redisTemplate.opsForHash().entries(key);
+
+		return entries.entrySet().stream()
+			.collect(Collectors.toMap(
+				e -> e.getKey().toString(),
+				Map.Entry::getValue
+			));
+	}
+}

--- a/membership-service/src/main/java/com/boeingmerryho/business/membershipservice/infrastructure/config/auth/WebMvcConfig.java
+++ b/membership-service/src/main/java/com/boeingmerryho/business/membershipservice/infrastructure/config/auth/WebMvcConfig.java
@@ -1,0 +1,32 @@
+package com.boeingmerryho.business.membershipservice.infrastructure.config.auth;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import io.github.boeingmerryho.commonlibrary.interceptor.AdminCheckInterceptor;
+import io.github.boeingmerryho.commonlibrary.interceptor.UserCheckInterceptor;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+	private final RedisUserInfoProvider userInfoProvider;
+
+	public WebMvcConfig(RedisUserInfoProvider userInfoProvider) {
+		this.userInfoProvider = userInfoProvider;
+	}
+
+	@Override
+	public void addInterceptors(InterceptorRegistry registry) {
+		registry.addInterceptor(new UserCheckInterceptor(userInfoProvider))
+			.excludePathPatterns(
+				"/membership-service/**",
+				"/error/**");
+
+		registry.addInterceptor(new AdminCheckInterceptor(userInfoProvider))
+			.excludePathPatterns(
+				"/api/**",
+				"/membership-service/**",
+				"/error/**");
+	}
+}

--- a/membership-service/src/main/java/com/boeingmerryho/business/membershipservice/presentation/controller/admin/MembershipAdminController.java
+++ b/membership-service/src/main/java/com/boeingmerryho/business/membershipservice/presentation/controller/admin/MembershipAdminController.java
@@ -28,10 +28,14 @@ import com.boeingmerryho.business.membershipservice.presentation.dto.response.Me
 import com.boeingmerryho.business.membershipservice.presentation.dto.response.MembershipUpdateResponseDto;
 import com.boeingmerryho.business.membershipservice.utils.PageableUtils;
 
+import io.github.boeingmerryho.commonlibrary.entity.UserRoleType;
+import io.github.boeingmerryho.commonlibrary.interceptor.RequiredRoles;
 import io.github.boeingmerryho.commonlibrary.response.SuccessResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/admin/v1/memberships")
@@ -41,6 +45,7 @@ public class MembershipAdminController {
 	private final MembershipAdminService membershipAdminService;
 
 	@PostMapping
+	@RequiredRoles({UserRoleType.ADMIN, UserRoleType.MANAGER})
 	public ResponseEntity<SuccessResponse<MembershipCreateResponseDto>> createMembership(
 		@RequestBody @Valid MembershipCreateRequestDto requestDto
 	) {
@@ -52,6 +57,7 @@ public class MembershipAdminController {
 	}
 
 	@GetMapping("/{id}")
+	@RequiredRoles({UserRoleType.ADMIN, UserRoleType.MANAGER})
 	public ResponseEntity<SuccessResponse<MembershipDetailAdminResponseDto>> getMembershipDetail(
 		@PathVariable Long id
 	) {
@@ -61,6 +67,7 @@ public class MembershipAdminController {
 	}
 
 	@GetMapping
+	@RequiredRoles({UserRoleType.ADMIN, UserRoleType.MANAGER})
 	public ResponseEntity<SuccessResponse<Page<MembershipSearchAdminResponseDto>>> searchMembership(
 		@RequestParam(value = "page", required = false, defaultValue = "1") int page,
 		@RequestParam(value = "size", required = false, defaultValue = "10") int size,
@@ -86,6 +93,7 @@ public class MembershipAdminController {
 	}
 
 	@PutMapping("/{id}")
+	@RequiredRoles({UserRoleType.ADMIN, UserRoleType.MANAGER})
 	public ResponseEntity<SuccessResponse<MembershipUpdateResponseDto>> updateMembership(
 		@PathVariable Long id,
 		@RequestBody MembershipUpdateRequestDto requestDto
@@ -98,6 +106,7 @@ public class MembershipAdminController {
 	}
 
 	@DeleteMapping("/{id}")
+	@RequiredRoles({UserRoleType.ADMIN, UserRoleType.MANAGER})
 	public ResponseEntity<SuccessResponse<Void>> deleteMembership(
 		@PathVariable Long id
 	) {

--- a/membership-service/src/main/java/com/boeingmerryho/business/membershipservice/presentation/controller/admin/MembershipUserAdminController.java
+++ b/membership-service/src/main/java/com/boeingmerryho/business/membershipservice/presentation/controller/admin/MembershipUserAdminController.java
@@ -19,6 +19,8 @@ import com.boeingmerryho.business.membershipservice.presentation.dto.response.Me
 import com.boeingmerryho.business.membershipservice.presentation.dto.response.MembershipUserSearchAdminResponseDto;
 import com.boeingmerryho.business.membershipservice.utils.PageableUtils;
 
+import io.github.boeingmerryho.commonlibrary.entity.UserRoleType;
+import io.github.boeingmerryho.commonlibrary.interceptor.RequiredRoles;
 import io.github.boeingmerryho.commonlibrary.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 
@@ -31,6 +33,7 @@ public class MembershipUserAdminController {
 	private final MembershipUserAdminService membershipUserAdminService;
 
 	@GetMapping("/users/{id}")
+	@RequiredRoles({UserRoleType.ADMIN, UserRoleType.MANAGER})
 	public ResponseEntity<SuccessResponse<MembershipUserDetailAdminResponseDto>> getMembershipUserDetail(
 		@PathVariable Long id
 	) {
@@ -42,6 +45,7 @@ public class MembershipUserAdminController {
 	}
 
 	@GetMapping("/users")
+	@RequiredRoles({UserRoleType.ADMIN, UserRoleType.MANAGER})
 	public ResponseEntity<SuccessResponse<Page<MembershipUserSearchAdminResponseDto>>> searchMembershipUser(
 		@RequestParam(value = "page", required = false, defaultValue = "1") int page,
 		@RequestParam(value = "size", required = false, defaultValue = "10") int size,
@@ -66,6 +70,7 @@ public class MembershipUserAdminController {
 	}
 
 	@PostMapping("/{season}/deactivate")
+	@RequiredRoles({UserRoleType.ADMIN, UserRoleType.MANAGER})
 	public ResponseEntity<SuccessResponse<Integer>> deactivateUsersOfSeason(@PathVariable Integer season) {
 		Integer count = membershipUserAdminService.deactivateUsersOfSeason(season);
 		return SuccessResponse.of(MembershipSuccessCode.DEACTIVATED_MEMBERSHIP_USERS, count);

--- a/membership-service/src/main/java/com/boeingmerryho/business/membershipservice/presentation/controller/feign/MembershipFeignController.java
+++ b/membership-service/src/main/java/com/boeingmerryho/business/membershipservice/presentation/controller/feign/MembershipFeignController.java
@@ -17,13 +17,13 @@ public class MembershipFeignController {
 
 	private final MembershipFeignService membershipFeignService;
 
-	@PostMapping("/membership/user/login")
+	@PostMapping("/membership-service/memberships/users/login")
 	public ResponseEntity<String> notifyLogin(@RequestBody LoginSuccessRequest request) {
 		membershipFeignService.handleLoginSuccess(request);
 		return ResponseEntity.ok("사용자 멤버십 정보 등록 완료");
 	}
 
-	@PostMapping("/membership/payment/discount")
+	@PostMapping("/membership-service/memberships/payments/discount")
 	public ResponseEntity<Double> getDiscount(@RequestBody UserDiscountRequest request) {
 		Double discount = membershipFeignService.getDiscountById(request.userId());
 		return ResponseEntity.ok(discount);

--- a/membership-service/src/main/java/com/boeingmerryho/business/membershipservice/presentation/controller/user/MembershipController.java
+++ b/membership-service/src/main/java/com/boeingmerryho/business/membershipservice/presentation/controller/user/MembershipController.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -18,6 +19,8 @@ import com.boeingmerryho.business.membershipservice.presentation.dto.mapper.Memb
 import com.boeingmerryho.business.membershipservice.presentation.dto.response.MembershipDetailResponseDto;
 import com.boeingmerryho.business.membershipservice.presentation.dto.response.MembershipUserCreateResponseDto;
 
+import io.github.boeingmerryho.commonlibrary.entity.UserRoleType;
+import io.github.boeingmerryho.commonlibrary.interceptor.RequiredRoles;
 import io.github.boeingmerryho.commonlibrary.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 
@@ -38,11 +41,11 @@ public class MembershipController {
 	}
 
 	@PostMapping("/{membershipId}/reserve")
+	@RequiredRoles({UserRoleType.NORMAL, UserRoleType.SENIOR})
 	public ResponseEntity<SuccessResponse<MembershipUserCreateResponseDto>> reserveMembership(
-		@PathVariable Long membershipId
+		@PathVariable Long membershipId,
+		@RequestAttribute Long userId
 	) {
-		// TODO: userId 받아오기
-		Long userId = 6L;
 		MembershipUserCreateResponseServiceDto responseServiceDto = membershipReserveService.reserveMembership(
 			mapper.toMembershipUserCreateRequestServiceDto(membershipId, userId));
 		MembershipUserCreateResponseDto responseDto = mapper.toMembershipUserCreateResponseDto(responseServiceDto);

--- a/membership-service/src/main/java/com/boeingmerryho/business/membershipservice/presentation/controller/user/MembershipUserController.java
+++ b/membership-service/src/main/java/com/boeingmerryho/business/membershipservice/presentation/controller/user/MembershipUserController.java
@@ -3,6 +3,7 @@ package com.boeingmerryho.business.membershipservice.presentation.controller.use
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -12,6 +13,8 @@ import com.boeingmerryho.business.membershipservice.presentation.dto.MembershipS
 import com.boeingmerryho.business.membershipservice.presentation.dto.mapper.MembershipPresentationMapper;
 import com.boeingmerryho.business.membershipservice.presentation.dto.response.MembershipUserDetailResponseDto;
 
+import io.github.boeingmerryho.commonlibrary.entity.UserRoleType;
+import io.github.boeingmerryho.commonlibrary.interceptor.RequiredRoles;
 import io.github.boeingmerryho.commonlibrary.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 
@@ -24,11 +27,11 @@ public class MembershipUserController {
 	private final MembershipUserService membershipUserService;
 
 	@GetMapping("/users/season/{season}")
+	@RequiredRoles({UserRoleType.NORMAL, UserRoleType.SENIOR})
 	public ResponseEntity<SuccessResponse<MembershipUserDetailResponseDto>> getMembershipUserDetail(
-		@PathVariable Integer season
+		@PathVariable Integer season,
+		@RequestAttribute Long userId
 	) {
-		//TODO: userId 받아오기
-		Long userId = 3L;
 		MembershipUserDetailResponseServiceDto responseServiceDto = membershipUserService.getMembershipUser(
 			season, userId);
 		MembershipUserDetailResponseDto responseDto = mapper.toMembershipUserDetailResponseDto(


### PR DESCRIPTION
## PR Type
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Summary : 변경 내용
- **as-is**
  - feign-client url convention 에 맞지 않음

- **to-be**
  - feign-client url convention 통일
  - userId Interceptor에서 받아오기
  - redis 공용 서버로 변경

## Issue Number
- close #170 

## Etc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced role-based access control for various admin and user endpoints, restricting actions to specific user roles (e.g., ADMIN, MANAGER, NORMAL, SENIOR).
  - Added a new provider for fetching user information from Redis.
  - Implemented HTTP request interceptors for user and admin checks, with selective path exclusions.

- **Enhancements**
  - Updated endpoint URLs for payment creation and membership-related Feign APIs.
  - Improved controller methods to accept user IDs from request attributes instead of hardcoded values.

- **Bug Fixes**
  - Adjusted login success handling to avoid exceptions when no active membership is found, improving system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->