### PR TITLE
[Store] : 1차 리팩토링

### DIFF
--- a/membership-service/src/main/java/com/boeingmerryho/business/membershipservice/exception/GlobalExceptionHandler.java
+++ b/membership-service/src/main/java/com/boeingmerryho/business/membershipservice/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import java.util.stream.Collectors;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.handler.annotation.support.MethodArgumentTypeMismatchException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -39,5 +40,22 @@ public class GlobalExceptionHandler {
 		return ResponseEntity
 			.status(HttpStatus.BAD_REQUEST)
 			.body(ErrorResponse.of("VALIDATION_ERROR", message));
+	}
+
+	@ExceptionHandler(MethodArgumentTypeMismatchException.class)
+	public ResponseEntity<ErrorResponse> handleEnumConversion(MethodArgumentTypeMismatchException ex) {
+		return ResponseEntity
+			.status(HttpStatus.BAD_REQUEST)
+			.body(ErrorResponse.of("INVALID_ENUM", "잘못된 상태 값입니다."));
+	}
+
+	@ExceptionHandler(IllegalArgumentException.class)
+	public ResponseEntity<ErrorResponse> handleIllegalArgument(IllegalArgumentException e) {
+		if (e.getMessage() != null && e.getMessage().contains("No enum constant")) {
+			return ResponseEntity
+				.status(HttpStatus.BAD_REQUEST)
+				.body(ErrorResponse.of("INVALID_STATUS", "지원하지 않는 상태 값입니다."));
+		}
+		return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
 	}
 }

--- a/membership-service/src/main/java/com/boeingmerryho/business/membershipservice/infrastructure/helper/MembershipRedisHelper.java
+++ b/membership-service/src/main/java/com/boeingmerryho/business/membershipservice/infrastructure/helper/MembershipRedisHelper.java
@@ -30,7 +30,6 @@ public class MembershipRedisHelper {
 			end
 			redis.call("DECR", KEYS[1])
 			redis.call("SET", KEYS[2], ARGV[2])
-			redis.call("EXPIRE", KEYS[1], ARGV[3])
 			redis.call("EXPIRE", KEYS[2], ARGV[3])
 			return 1
 		""";

--- a/membership-service/src/main/java/com/boeingmerryho/business/membershipservice/infrastructure/helper/MembershipRedisHelper.java
+++ b/membership-service/src/main/java/com/boeingmerryho/business/membershipservice/infrastructure/helper/MembershipRedisHelper.java
@@ -21,18 +21,21 @@ public class MembershipRedisHelper {
 	private static final String MEMBERSHIP_STOCK_PREFIX = "membership:stock:";
 	private static final String MEMBERSHIP_USER_PREFIX = "membership:user:";
 	private static final String LUA_SCRIPT = """
-			local stock = tonumber(redis.call("GET", KEYS[1]))
-			if not stock or stock <= 0 then
+			local remain = tonumber(redis.call("DECR", KEYS[1]))
+			if remain < 0 then
+				redis.call("INCR", KEYS[1]);
 				return -1
 			end
 			if redis.call("EXISTS", KEYS[2]) == 1 then
 				return -2
 			end
-			redis.call("DECR", KEYS[1])
 			redis.call("SET", KEYS[2], ARGV[2])
 			redis.call("EXPIRE", KEYS[2], ARGV[3])
 			return 1
 		""";
+	// TODO redis.call("SET", KEYS[2], ARGV[2]) -> EX 설정 + remain 0 미만이면 -1 하기 전에 INCR
+	// TODO redis command 각각 쪼개기 방법이랑 비교
+	// TODO SET 자료구조 활용하면 심플하게 변경 가능하니 고려
 
 	public void reserve(Long membershipId, Long userId, Duration ttl) {
 		String stockKey = MEMBERSHIP_STOCK_PREFIX + membershipId;
@@ -41,6 +44,7 @@ public class MembershipRedisHelper {
 		DefaultRedisScript<Long> redisScript = new DefaultRedisScript<>(LUA_SCRIPT, Long.class);
 
 		try {
+			// redis 명령어로 재고 체크
 			Long result = redisTemplate.execute(
 				redisScript,
 				List.of(stockKey, userKey),

--- a/membership-service/src/main/java/com/boeingmerryho/business/membershipservice/presentation/controller/user/MembershipController.java
+++ b/membership-service/src/main/java/com/boeingmerryho/business/membershipservice/presentation/controller/user/MembershipController.java
@@ -4,23 +4,15 @@ import java.util.List;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.boeingmerryho.business.membershipservice.application.dto.response.MembershipDetailResponseServiceDto;
-import com.boeingmerryho.business.membershipservice.application.dto.response.MembershipUserCreateResponseServiceDto;
-import com.boeingmerryho.business.membershipservice.application.service.user.MembershipReserveService;
 import com.boeingmerryho.business.membershipservice.application.service.user.MembershipService;
 import com.boeingmerryho.business.membershipservice.presentation.dto.MembershipSuccessCode;
 import com.boeingmerryho.business.membershipservice.presentation.dto.mapper.MembershipPresentationMapper;
 import com.boeingmerryho.business.membershipservice.presentation.dto.response.MembershipDetailResponseDto;
-import com.boeingmerryho.business.membershipservice.presentation.dto.response.MembershipUserCreateResponseDto;
 
-import io.github.boeingmerryho.commonlibrary.entity.UserRoleType;
-import io.github.boeingmerryho.commonlibrary.interceptor.RequiredRoles;
 import io.github.boeingmerryho.commonlibrary.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 
@@ -31,7 +23,6 @@ public class MembershipController {
 
 	private final MembershipPresentationMapper mapper;
 	private final MembershipService membershipService;
-	private final MembershipReserveService membershipReserveService;
 
 	@GetMapping("/season")
 	public ResponseEntity<SuccessResponse<List<MembershipDetailResponseDto>>> getMembershipsByCurrentSeason() {
@@ -40,15 +31,4 @@ public class MembershipController {
 		return SuccessResponse.of(MembershipSuccessCode.FETCHED_MEMBERSHIP, responseDto);
 	}
 
-	@PostMapping("/{membershipId}/reserve")
-	@RequiredRoles({UserRoleType.NORMAL, UserRoleType.SENIOR})
-	public ResponseEntity<SuccessResponse<MembershipUserCreateResponseDto>> reserveMembership(
-		@PathVariable Long membershipId,
-		@RequestAttribute Long userId
-	) {
-		MembershipUserCreateResponseServiceDto responseServiceDto = membershipReserveService.reserveMembership(
-			mapper.toMembershipUserCreateRequestServiceDto(membershipId, userId));
-		MembershipUserCreateResponseDto responseDto = mapper.toMembershipUserCreateResponseDto(responseServiceDto);
-		return SuccessResponse.of(MembershipSuccessCode.CREATED_MEMBERSHIP_USER, responseDto);
-	}
 }

--- a/membership-service/src/main/java/com/boeingmerryho/business/membershipservice/presentation/controller/user/MembershipUserController.java
+++ b/membership-service/src/main/java/com/boeingmerryho/business/membershipservice/presentation/controller/user/MembershipUserController.java
@@ -3,14 +3,18 @@ package com.boeingmerryho.business.membershipservice.presentation.controller.use
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.boeingmerryho.business.membershipservice.application.dto.response.MembershipUserCreateResponseServiceDto;
 import com.boeingmerryho.business.membershipservice.application.dto.response.MembershipUserDetailResponseServiceDto;
+import com.boeingmerryho.business.membershipservice.application.service.user.MembershipReserveService;
 import com.boeingmerryho.business.membershipservice.application.service.user.MembershipUserService;
 import com.boeingmerryho.business.membershipservice.presentation.dto.MembershipSuccessCode;
 import com.boeingmerryho.business.membershipservice.presentation.dto.mapper.MembershipPresentationMapper;
+import com.boeingmerryho.business.membershipservice.presentation.dto.response.MembershipUserCreateResponseDto;
 import com.boeingmerryho.business.membershipservice.presentation.dto.response.MembershipUserDetailResponseDto;
 
 import io.github.boeingmerryho.commonlibrary.entity.UserRoleType;
@@ -25,6 +29,7 @@ public class MembershipUserController {
 
 	private final MembershipPresentationMapper mapper;
 	private final MembershipUserService membershipUserService;
+	private final MembershipReserveService membershipReserveService;
 
 	@GetMapping("/users/season/{season}")
 	@RequiredRoles({UserRoleType.NORMAL, UserRoleType.SENIOR})
@@ -37,5 +42,17 @@ public class MembershipUserController {
 		MembershipUserDetailResponseDto responseDto = mapper.toMembershipUserDetailResponseDto(
 			responseServiceDto);
 		return SuccessResponse.of(MembershipSuccessCode.FETCHED_MEMBERSHIP_USER, responseDto);
+	}
+
+	@PostMapping("/{membershipId}/reserve")
+	@RequiredRoles({UserRoleType.NORMAL, UserRoleType.SENIOR})
+	public ResponseEntity<SuccessResponse<MembershipUserCreateResponseDto>> reserveMembership(
+		@PathVariable Long membershipId,
+		@RequestAttribute Long userId
+	) {
+		MembershipUserCreateResponseServiceDto responseServiceDto = membershipReserveService.reserveMembership(
+			mapper.toMembershipUserCreateRequestServiceDto(membershipId, userId));
+		MembershipUserCreateResponseDto responseDto = mapper.toMembershipUserCreateResponseDto(responseServiceDto);
+		return SuccessResponse.of(MembershipSuccessCode.CREATED_MEMBERSHIP_USER, responseDto);
 	}
 }

--- a/store-service/src/main/java/com/boeingmerryho/business/storeservice/application/service/StoreAdminService.java
+++ b/store-service/src/main/java/com/boeingmerryho/business/storeservice/application/service/StoreAdminService.java
@@ -12,6 +12,8 @@ import com.boeingmerryho.business.storeservice.application.dto.response.StoreCre
 import com.boeingmerryho.business.storeservice.application.dto.response.StoreDetailAdminResponseServiceDto;
 import com.boeingmerryho.business.storeservice.application.dto.response.StoreSearchAdminResponseServiceDto;
 import com.boeingmerryho.business.storeservice.application.dto.response.StoreUpdateResponseServiceDto;
+import com.boeingmerryho.business.storeservice.application.service.command.StoreCommandFactory;
+import com.boeingmerryho.business.storeservice.application.service.command.StoreCommandType;
 import com.boeingmerryho.business.storeservice.domain.entity.Store;
 import com.boeingmerryho.business.storeservice.infrastructure.helper.StoreAdminHelper;
 import com.boeingmerryho.business.storeservice.infrastructure.helper.StoreQueueAdminHelper;
@@ -26,6 +28,7 @@ public class StoreAdminService {
 	private final StoreValidator validator;
 	private final StoreApplicationMapper mapper;
 	private final StoreAdminHelper storeAdminHelper;
+	private final StoreCommandFactory storeCommandFactory;
 	private final StoreQueueAdminHelper storeQueueAdminHelper;
 
 	@Transactional
@@ -60,15 +63,10 @@ public class StoreAdminService {
 	}
 
 	@Transactional
-	public StoreUpdateResponseServiceDto openStore(Long id) {
-		Store opened = storeAdminHelper.updateStoreOpen(id);
-		return mapper.toStoreUpdateResponseServiceDto(opened);
-	}
-
-	@Transactional
-	public StoreUpdateResponseServiceDto closeStore(Long id) {
-		Store closed = storeAdminHelper.updateStoreClose(id);
-		return mapper.toStoreUpdateResponseServiceDto(closed);
+	public StoreUpdateResponseServiceDto changeStoreStatus(Long id, StoreCommandType type) {
+		storeCommandFactory.getCommand(type).execute(id);
+		Store store = storeAdminHelper.getAnyStoreById(id);
+		return mapper.toStoreUpdateResponseServiceDto(store);
 	}
 
 	public void enableQueue(Long id) {

--- a/store-service/src/main/java/com/boeingmerryho/business/storeservice/application/service/command/CloseStoreCommand.java
+++ b/store-service/src/main/java/com/boeingmerryho/business/storeservice/application/service/command/CloseStoreCommand.java
@@ -1,0 +1,18 @@
+package com.boeingmerryho.business.storeservice.application.service.command;
+
+import org.springframework.stereotype.Component;
+
+import com.boeingmerryho.business.storeservice.infrastructure.helper.StoreAdminHelper;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class CloseStoreCommand implements StoreCommand {
+	private final StoreAdminHelper storeAdminHelper;
+
+	@Override
+	public void execute(Long storeId) {
+		storeAdminHelper.updateStoreClose(storeId);
+	}
+}

--- a/store-service/src/main/java/com/boeingmerryho/business/storeservice/application/service/command/OpenStoreCommand.java
+++ b/store-service/src/main/java/com/boeingmerryho/business/storeservice/application/service/command/OpenStoreCommand.java
@@ -1,0 +1,18 @@
+package com.boeingmerryho.business.storeservice.application.service.command;
+
+import org.springframework.stereotype.Component;
+
+import com.boeingmerryho.business.storeservice.infrastructure.helper.StoreAdminHelper;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class OpenStoreCommand implements StoreCommand {
+	private final StoreAdminHelper storeAdminHelper;
+
+	@Override
+	public void execute(Long storeId) {
+		storeAdminHelper.updateStoreOpen(storeId);
+	}
+}

--- a/store-service/src/main/java/com/boeingmerryho/business/storeservice/application/service/command/StoreCommand.java
+++ b/store-service/src/main/java/com/boeingmerryho/business/storeservice/application/service/command/StoreCommand.java
@@ -1,0 +1,5 @@
+package com.boeingmerryho.business.storeservice.application.service.command;
+
+public interface StoreCommand {
+	void execute(Long storeId);
+}

--- a/store-service/src/main/java/com/boeingmerryho/business/storeservice/application/service/command/StoreCommandFactory.java
+++ b/store-service/src/main/java/com/boeingmerryho/business/storeservice/application/service/command/StoreCommandFactory.java
@@ -1,0 +1,20 @@
+package com.boeingmerryho.business.storeservice.application.service.command;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class StoreCommandFactory {
+
+	private final OpenStoreCommand openStoreCommand;
+	private final CloseStoreCommand closeStoreCommand;
+
+	public StoreCommand getCommand(StoreCommandType type) {
+		return switch (type) {
+			case OPEN -> openStoreCommand;
+			case CLOSE -> closeStoreCommand;
+		};
+	}
+}

--- a/store-service/src/main/java/com/boeingmerryho/business/storeservice/application/service/command/StoreCommandType.java
+++ b/store-service/src/main/java/com/boeingmerryho/business/storeservice/application/service/command/StoreCommandType.java
@@ -1,0 +1,20 @@
+package com.boeingmerryho.business.storeservice.application.service.command;
+
+import com.boeingmerryho.business.storeservice.exception.StoreErrorCode;
+
+import io.github.boeingmerryho.commonlibrary.exception.GlobalException;
+
+public enum StoreCommandType {
+	OPEN,
+	CLOSE,
+	;
+
+	public static StoreCommandType from(String value) {
+		try {
+			return StoreCommandType.valueOf(value.toUpperCase());
+		} catch (IllegalArgumentException | NullPointerException e) {
+			throw new GlobalException(StoreErrorCode.INVALID_STATUS);
+		}
+	}
+
+}

--- a/store-service/src/main/java/com/boeingmerryho/business/storeservice/exception/StoreErrorCode.java
+++ b/store-service/src/main/java/com/boeingmerryho/business/storeservice/exception/StoreErrorCode.java
@@ -12,6 +12,7 @@ public enum StoreErrorCode implements BaseErrorCode {
 	NO_UPDATE_FIELDS_PROVIDED(HttpStatus.BAD_REQUEST, "STORE_004", "필드 값이 유효하지 않습니다."),
 	ALREADY_CLOSED(HttpStatus.BAD_REQUEST, "STORE_005", "이미 마감되었습니다."),
 	ALREADY_OPENED(HttpStatus.BAD_REQUEST, "STORE_006", "이미 오픈되었습니다."),
+	INVALID_STATUS(HttpStatus.BAD_REQUEST, "STORE_007", "잘못된 상태값입니다."),
 	;
 
 	private final HttpStatus status;

--- a/store-service/src/main/java/com/boeingmerryho/business/storeservice/infrastructure/config/RedisConfig.java
+++ b/store-service/src/main/java/com/boeingmerryho/business/storeservice/infrastructure/config/RedisConfig.java
@@ -21,6 +21,9 @@ public class RedisConfig {
 	@Value("${spring.data.redis.host}")
 	private String host;
 
+	@Value("${spring.data.redis.username}")
+	private String username;
+
 	@Value("${spring.data.redis.port}")
 	private int port;
 
@@ -39,7 +42,7 @@ public class RedisConfig {
 	@Bean
 	public RedisConnectionFactory redisConnectionFactory() {
 		RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(host, port);
-		config.setUsername("default");
+		config.setUsername(username);
 		config.setPassword(password);
 		return new LettuceConnectionFactory(config);
 	}
@@ -53,7 +56,7 @@ public class RedisConfig {
 	@Bean
 	public RedisConnectionFactory redisConnectionGlobalFactory() {
 		RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(globalHost, globalPort);
-		config.setUsername("default");
+		config.setUsername(username);
 		config.setPassword(globalPassword);
 		return new LettuceConnectionFactory(config);
 	}

--- a/store-service/src/main/java/com/boeingmerryho/business/storeservice/infrastructure/helper/StoreAdminHelper.java
+++ b/store-service/src/main/java/com/boeingmerryho/business/storeservice/infrastructure/helper/StoreAdminHelper.java
@@ -49,18 +49,16 @@ public class StoreAdminHelper {
 			.orElseThrow(() -> new GlobalException(StoreErrorCode.NOT_FOUND));
 	}
 
-	public Store updateStoreOpen(Long id) {
+	public void updateStoreOpen(Long id) {
 		Store store = storeRepository.findByIdAndIsDeletedFalse(id)
 			.orElseThrow(() -> new GlobalException(StoreErrorCode.NOT_FOUND));
 		store.open();
-		return store;
 	}
 
-	public Store updateStoreClose(Long id) {
+	public void updateStoreClose(Long id) {
 		Store store = storeRepository.findByIdAndIsDeletedFalse(id)
 			.orElseThrow(() -> new GlobalException(StoreErrorCode.NOT_FOUND));
 		store.close();
-		return store;
 	}
 
 	public void deleteStore(Long id) {

--- a/store-service/src/main/java/com/boeingmerryho/business/storeservice/infrastructure/scheduler/RedisZSetDelayQueuePoller.java
+++ b/store-service/src/main/java/com/boeingmerryho/business/storeservice/infrastructure/scheduler/RedisZSetDelayQueuePoller.java
@@ -41,3 +41,4 @@ public class RedisZSetDelayQueuePoller {
 		}
 	}
 }
+// TODO 특정 날짜의 특정 가게 정보 prefix 를 키로 둔 time 값을 저장

--- a/store-service/src/main/java/com/boeingmerryho/business/storeservice/infrastructure/scheduler/StoreDailyQueueScheduler.java
+++ b/store-service/src/main/java/com/boeingmerryho/business/storeservice/infrastructure/scheduler/StoreDailyQueueScheduler.java
@@ -23,6 +23,9 @@ public class StoreDailyQueueScheduler {
 	@Scheduled(cron = "0 0 0 * * *")
 	public void scheduleDailyQueue() {
 		List<Store> stores = storeRepository.findAllByIsDeletedFalse();
+		// TODO 배치로 id만 가져온다든지, 특정 가게만 가져온다든지 이벤트 payload에 넣고 뿌리기
+		// TODO Lock이 안걸려있기 때문에 Lock 추가해야함
+		// TODO 인덱싱 처리하면 가게 날짜별로 검색할때에도 빠르게 조회 검색 가능!
 
 		for (Store store : stores) {
 			LocalDateTime todayOpenAt = LocalDateTime.of(LocalDate.now(), store.getOpenAt().toLocalTime());

--- a/store-service/src/main/java/com/boeingmerryho/business/storeservice/presentation/StoreSuccessCode.java
+++ b/store-service/src/main/java/com/boeingmerryho/business/storeservice/presentation/StoreSuccessCode.java
@@ -14,6 +14,7 @@ public enum StoreSuccessCode implements SuccessCode {
 	QUEUE_ENABLED("줄서기 가능 상태로 전환되었습니다.", HttpStatus.OK),
 	QUEUE_DISABLED("줄서기 불가능 상태로 전환되었습니다.", HttpStatus.OK),
 	DELETE_STORE("매장이 삭제되었습니다.", HttpStatus.OK),
+	CHANGE_STORE_STATUS("매장 상태가 변경되었습니다.", HttpStatus.OK),
 	;
 
 	private final String message;

--- a/store-service/src/main/java/com/boeingmerryho/business/storeservice/presentation/controller/StoreAdminController.java
+++ b/store-service/src/main/java/com/boeingmerryho/business/storeservice/presentation/controller/StoreAdminController.java
@@ -18,6 +18,7 @@ import com.boeingmerryho.business.storeservice.application.dto.response.StoreDet
 import com.boeingmerryho.business.storeservice.application.dto.response.StoreSearchAdminResponseServiceDto;
 import com.boeingmerryho.business.storeservice.application.dto.response.StoreUpdateResponseServiceDto;
 import com.boeingmerryho.business.storeservice.application.service.StoreAdminService;
+import com.boeingmerryho.business.storeservice.application.service.command.StoreCommandType;
 import com.boeingmerryho.business.storeservice.presentation.StoreSuccessCode;
 import com.boeingmerryho.business.storeservice.presentation.dto.mapper.StorePresentationMapper;
 import com.boeingmerryho.business.storeservice.presentation.dto.request.StoreCreateRequestDto;
@@ -97,24 +98,16 @@ public class StoreAdminController {
 		return SuccessResponse.of(StoreSuccessCode.UPDATED_STORE, responseDto);
 	}
 
-	@PutMapping("/{id}/open")
+	@PutMapping("/{id}/status")
 	@RequiredRoles({UserRoleType.ADMIN, UserRoleType.MANAGER})
-	public ResponseEntity<SuccessResponse<StoreUpdateResponseDto>> openStore(
-		@PathVariable Long id
+	public ResponseEntity<SuccessResponse<StoreUpdateResponseDto>> changeStoreStatus(
+		@PathVariable Long id,
+		@RequestParam(value = "status") String type
 	) {
-		StoreUpdateResponseServiceDto responseDtoService = storeAdminService.openStore(id);
+		StoreCommandType commandType = StoreCommandType.from(type);
+		StoreUpdateResponseServiceDto responseDtoService = storeAdminService.changeStoreStatus(id, commandType);
 		StoreUpdateResponseDto responseDto = mapper.toStoreUpdateResponseDto(responseDtoService);
-		return SuccessResponse.of(StoreSuccessCode.OPEN_STORE, responseDto);
-	}
-
-	@PutMapping("/{id}/close")
-	@RequiredRoles({UserRoleType.ADMIN, UserRoleType.MANAGER})
-	public ResponseEntity<SuccessResponse<StoreUpdateResponseDto>> closeStore(
-		@PathVariable Long id
-	) {
-		StoreUpdateResponseServiceDto responseDtoService = storeAdminService.closeStore(id);
-		StoreUpdateResponseDto responseDto = mapper.toStoreUpdateResponseDto(responseDtoService);
-		return SuccessResponse.of(StoreSuccessCode.CLOSE_STORE, responseDto);
+		return SuccessResponse.of(StoreSuccessCode.CHANGE_STORE_STATUS, responseDto);
 	}
 
 	@PutMapping("/{id}/queue/enable")


### PR DESCRIPTION
## PR Type
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Summary : 변경 내용
- **as-is**
  - 가게 open/close 두가지 상태를 고려한 설계

- **to-be**
  - 가게 상태 추가를 고려한 command 패턴으로 리팩토링

## Issue Number
- close #73 

## Etc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a consolidated endpoint for changing store status (open/close) via a single API with a status parameter.
  - Introduced new error handling for invalid status values and enum conversion errors.
  - Added a new endpoint for reserving memberships under user management.

- **Improvements**
  - Updated Redis configuration to support dynamic usernames from application properties.
  - Enhanced store status management using a command pattern for better extensibility.

- **Refactor**
  - Unified store open/close logic into a single service and controller method.
  - Removed the old membership reservation endpoint from its previous controller and relocated it for improved organization.

- **Bug Fixes**
  - Improved error responses for invalid or unsupported status values in API requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->