### PR TITLE
[Queue] : 대기열 서비스 리펙토링

### DIFF
--- a/queue-service/src/main/java/com/boeingmerryho/business/queueservice/application/QueuePersistenceHelper.java
+++ b/queue-service/src/main/java/com/boeingmerryho/business/queueservice/application/QueuePersistenceHelper.java
@@ -1,0 +1,22 @@
+package com.boeingmerryho.business.queueservice.application;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import com.boeingmerryho.business.queueservice.application.dto.request.admin.QueueAdminSearchHistoryServiceDto;
+import com.boeingmerryho.business.queueservice.domain.entity.Queue;
+import com.boeingmerryho.business.queueservice.domain.entity.QueueSearchCriteria;
+
+public interface QueuePersistenceHelper {
+
+	public Queue saveQueueInfo(Queue queue);
+
+	QueueSearchCriteria getQueueSearchCriteria(QueueAdminSearchHistoryServiceDto requestDto);
+
+	Page<Queue> searchHistoryByDynamicQuery(QueueSearchCriteria criteria, Pageable pageable);
+
+	Queue findQueueHistoryById(Long id);
+
+	void deleteQueueHistoryById(Long id, Long userId);
+}
+

--- a/queue-service/src/main/java/com/boeingmerryho/business/queueservice/application/QueueRedisHelper.java
+++ b/queue-service/src/main/java/com/boeingmerryho/business/queueservice/application/QueueRedisHelper.java
@@ -4,17 +4,12 @@ import java.time.LocalDate;
 import java.util.Date;
 import java.util.Set;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.redis.core.ZSetOperations;
 
-import com.boeingmerryho.business.queueservice.application.dto.request.admin.QueueAdminSearchHistoryServiceDto;
-import com.boeingmerryho.business.queueservice.domain.entity.Queue;
-import com.boeingmerryho.business.queueservice.domain.entity.QueueSearchCriteria;
 import com.boeingmerryho.business.queueservice.domain.model.QueueUserInfo;
 import com.boeingmerryho.business.queueservice.exception.ErrorCode;
 
-public interface QueueHelper {
+public interface QueueRedisHelper {
 	public Boolean validateStoreIsActive(Long storeId);
 
 	public Long validateTicket(Date matchDate, Long ticketId);
@@ -33,8 +28,6 @@ public interface QueueHelper {
 
 	public Boolean removeUserFromQueue(Long storeId, Long userId);
 
-	public Queue saveQueueInfo(Queue queue);
-
 	QueueUserInfo getNextUserInQueue(Long storeId);
 
 	String getWaitlistInfoPrefix(Long storeId);
@@ -43,12 +36,5 @@ public interface QueueHelper {
 
 	Long getTotalQueueSize(String redisKey);
 
-	QueueSearchCriteria getQueueSearchCriteria(QueueAdminSearchHistoryServiceDto requestDto);
-
-	Page<Queue> searchHistoryByDynamicQuery(QueueSearchCriteria criteria, Pageable pageable);
-
-	Queue findQueueHistoryById(Long id);
-
-	void deleteQueueHistoryById(Long id, Long userId);
 }
 

--- a/queue-service/src/main/java/com/boeingmerryho/business/queueservice/application/service/QueueAdminService.java
+++ b/queue-service/src/main/java/com/boeingmerryho/business/queueservice/application/service/QueueAdminService.java
@@ -87,7 +87,7 @@ public class QueueAdminService {
 
 		return queueApplicationMapper.toQueueAdminCallUserResponseDto(
 			storeId,
-			userInfo.userId(),
+			cancelledUser.getUserId(),
 			userInfo.rank()
 		);
 	}

--- a/queue-service/src/main/java/com/boeingmerryho/business/queueservice/application/service/QueueAdminService.java
+++ b/queue-service/src/main/java/com/boeingmerryho/business/queueservice/application/service/QueueAdminService.java
@@ -20,6 +20,7 @@ import com.boeingmerryho.business.queueservice.application.dto.request.admin.Que
 import com.boeingmerryho.business.queueservice.application.dto.request.admin.QueueAdminDeleteUserServiceDto;
 import com.boeingmerryho.business.queueservice.application.dto.request.admin.QueueAdminSearchHistoryServiceDto;
 import com.boeingmerryho.business.queueservice.application.dto.request.admin.QueueAdminUpdateHistoryServiceDto;
+import com.boeingmerryho.business.queueservice.config.aop.DistributedLock;
 import com.boeingmerryho.business.queueservice.domain.entity.Queue;
 import com.boeingmerryho.business.queueservice.domain.entity.QueueSearchCriteria;
 import com.boeingmerryho.business.queueservice.domain.model.CancelReason;
@@ -45,6 +46,7 @@ public class QueueAdminService {
 	private final QueuePersistenceHelper persistenceHelper;
 
 	@Description("대기열에서 사용자 강제 삭제 메서드")
+	@DistributedLock(key = "#dto.storeId")
 	public QueueAdminDeleteUserResponseDto deleteUserFromQueue(QueueAdminDeleteUserServiceDto dto) {
 		Long storeId = dto.storeId();
 		Long userId = dto.userId();
@@ -66,6 +68,7 @@ public class QueueAdminService {
 	}
 
 	@Description("대기열의 다음 사용자 호출 메서드")
+	@DistributedLock(key = "#dto.storeId")
 	public QueueAdminCallUserResponseDto callNextUserFromQueue(QueueAdminCallUserServiceDto dto) {
 		Long storeId = dto.storeId();
 		QueueUserInfo userInfo = redisHelper.getNextUserInQueue(storeId);

--- a/queue-service/src/main/java/com/boeingmerryho/business/queueservice/application/service/QueueService.java
+++ b/queue-service/src/main/java/com/boeingmerryho/business/queueservice/application/service/QueueService.java
@@ -59,9 +59,9 @@ public class QueueService {
 	}
 
 	@Description("가게 대기열에서 본인 순서를 조회하는 메서드")
-	public QueueUserRankResponseDto getRank(QueueUserSequenceServiceDto serviceDto) {
-		Long storeId = serviceDto.storeId();
-		Long userId = serviceDto.userId();
+	public QueueUserRankResponseDto getRank(QueueUserSequenceServiceDto dto) {
+		Long storeId = dto.storeId();
+		Long userId = dto.userId();
 
 		Integer rank = redisHelper.getUserQueuePosition(storeId, userId);
 
@@ -73,9 +73,10 @@ public class QueueService {
 	}
 
 	@Description("본인을 가게 대기열에서 삭제하는 메서드")
-	public QueueCancelResponseDto cancelQueue(QueueCancelServiceDto serviceDto) {
-		Long storeId = serviceDto.storeId();
-		Long userId = serviceDto.userId();
+	@DistributedLock(key = "#dto.storeId")
+	public QueueCancelResponseDto cancelQueue(QueueCancelServiceDto dto) {
+		Long storeId = dto.storeId();
+		Long userId = dto.userId();
 
 		Integer sequence = redisHelper.getUserSequencePosition(storeId, userId);
 

--- a/queue-service/src/main/java/com/boeingmerryho/business/queueservice/application/service/QueueService.java
+++ b/queue-service/src/main/java/com/boeingmerryho/business/queueservice/application/service/QueueService.java
@@ -46,7 +46,7 @@ public class QueueService {
 		}
 
 		Long ticketUserId = redisHelper.validateTicket(matchDate, ticketId);
-		log.info("ticketUserId : {}", ticketUserId);
+		log.debug("ticketUserId : {}", ticketUserId);
 		if (!Objects.equals(userId, ticketUserId)) {
 			throw new GlobalException(ErrorCode.USER_IS_NOT_MATCHED);
 		}

--- a/queue-service/src/main/java/com/boeingmerryho/business/queueservice/infrastructure/QueuePersistenceHelperImpl.java
+++ b/queue-service/src/main/java/com/boeingmerryho/business/queueservice/infrastructure/QueuePersistenceHelperImpl.java
@@ -1,0 +1,68 @@
+package com.boeingmerryho.business.queueservice.infrastructure;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+import com.boeingmerryho.business.queueservice.application.QueuePersistenceHelper;
+import com.boeingmerryho.business.queueservice.application.dto.request.admin.QueueAdminSearchHistoryServiceDto;
+import com.boeingmerryho.business.queueservice.domain.entity.Queue;
+import com.boeingmerryho.business.queueservice.domain.entity.QueueSearchCriteria;
+import com.boeingmerryho.business.queueservice.domain.repository.CustomQueueRepository;
+import com.boeingmerryho.business.queueservice.domain.repository.QueueRepository;
+import com.boeingmerryho.business.queueservice.exception.ErrorCode;
+
+import io.github.boeingmerryho.commonlibrary.exception.GlobalException;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class QueuePersistenceHelperImpl implements QueuePersistenceHelper {
+
+	private final QueueRepository queueRepository;
+	private final CustomQueueRepository customQueueRepository;
+
+	public QueuePersistenceHelperImpl(
+		QueueRepository queueRepository,
+		CustomQueueRepository customQueueRepository
+	) {
+		this.queueRepository = queueRepository;
+		this.customQueueRepository = customQueueRepository;
+	}
+
+	@Override
+	public Queue saveQueueInfo(Queue queue) {
+		return queueRepository.save(queue);
+	}
+
+	@Override
+	public QueueSearchCriteria getQueueSearchCriteria(QueueAdminSearchHistoryServiceDto requestDto) {
+		QueueSearchCriteria criteria = QueueSearchCriteria.builder()
+			.storeId(requestDto.storeId())
+			.userId(requestDto.userId())
+			.status(requestDto.status())
+			.cancelReason(requestDto.cancelReason())
+			.startDate(requestDto.startDate())
+			.endDate(requestDto.endDate())
+			.build();
+
+		return criteria;
+	}
+
+	@Override
+	public Page<Queue> searchHistoryByDynamicQuery(QueueSearchCriteria criteria, Pageable pageable) {
+		return customQueueRepository.findDynamicQuery(criteria, pageable);
+	}
+
+	@Override
+	public Queue findQueueHistoryById(Long id) {
+		return queueRepository.findAllById(id)
+			.orElseThrow(() -> new GlobalException(ErrorCode.QUEUE_HISTORY_NOT_FOUND));
+	}
+
+	@Override
+	public void deleteQueueHistoryById(Long id, Long userId) {
+		Queue queue = findQueueHistoryById(id);
+		queue.softDelete(userId);
+	}
+}


### PR DESCRIPTION
## PR Type
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Summary : 변경 내용
- **as-is**
  - 

- **to-be**
  - queueHelper redisHelper와 persistenceHelper로 분리
  - service 메서드에서 redis에 수정이 일어나는 메서드에 대해 분산 락 어노테이션 적용

## Issue Number
- close #218 

## Etc

helper 클래스 분리 및 자잘한 이슈 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Split queue management logic into separate Redis and persistence helper components for clearer separation of concerns.
  - Renamed and updated helper classes and interfaces to reflect their specific responsibilities.
  - Updated service classes to use the new Redis and persistence helpers.

- **New Features**
  - Introduced distributed locking on critical queue operations to enhance data consistency.
  - Added a dedicated persistence helper implementation for advanced queue history management.

- **Tests**
  - Updated concurrency tests to use the new Redis helper interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->