### PR TITLE
[Seat] : 좌석 선점하기 로직 수정 #269

### DIFF
--- a/seat-service/src/main/java/com/boeingmerryho/business/seatservice/application/service/KafkaListenerService.java
+++ b/seat-service/src/main/java/com/boeingmerryho/business/seatservice/application/service/KafkaListenerService.java
@@ -16,7 +16,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class ListenerService {
+public class KafkaListenerService {
 	private final SeatFailedService seatFailedService;
 	private final SeatListenerHelper seatListenerHelper;
 	private final SeatSucceedService seatSucceedService;

--- a/seat-service/src/main/java/com/boeingmerryho/business/seatservice/application/service/KafkaProducerService.java
+++ b/seat-service/src/main/java/com/boeingmerryho/business/seatservice/application/service/KafkaProducerService.java
@@ -1,0 +1,30 @@
+package com.boeingmerryho.business.seatservice.application.service;
+
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+import com.boeingmerryho.business.seatservice.application.dto.request.ToTicketDto;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KafkaProducerService {
+	private final KafkaTemplate<String, Object> kafkaTemplate;
+
+	public void sendTicketCreatedEvent(ToTicketDto toTicketDto) {
+		sendEvent("ticket-created", toTicketDto);
+	}
+
+	public <T> void sendEvent(String topic, T event) {
+		kafkaTemplate.send(topic, event).whenComplete((result, ex) -> {
+			if (ex != null) {
+				log.error("[{}] 카프카 전송 실패", topic, ex);
+			} else {
+				log.info("[{}] 카프카 전송 성공: {}", topic, event);
+			}
+		});
+	}
+}

--- a/seat-service/src/main/java/com/boeingmerryho/business/seatservice/application/service/SeatService.java
+++ b/seat-service/src/main/java/com/boeingmerryho/business/seatservice/application/service/SeatService.java
@@ -1,43 +1,27 @@
 package com.boeingmerryho.business.seatservice.application.service;
 
-import java.time.Duration;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
-import org.redisson.api.RBucket;
-import org.redisson.api.RList;
 import org.redisson.api.RLock;
 import org.redisson.api.RSet;
-import org.redisson.api.RedissonClient;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.boeingmerryho.business.seatservice.application.dto.mapper.SeatApplicationMapper;
 import com.boeingmerryho.business.seatservice.application.dto.request.CacheBlockServiceRequestDto;
-import com.boeingmerryho.business.seatservice.application.dto.request.CacheSeatProcessServiceRequestDto;
 import com.boeingmerryho.business.seatservice.application.dto.request.CacheSeatsProcessServiceRequestDto;
 import com.boeingmerryho.business.seatservice.application.dto.request.ToTicketDto;
 import com.boeingmerryho.business.seatservice.application.dto.request.ToTicketMatchDto;
 import com.boeingmerryho.business.seatservice.application.dto.request.ToTicketSeatDto;
 import com.boeingmerryho.business.seatservice.application.dto.response.CacheBlockServiceResponseDto;
 import com.boeingmerryho.business.seatservice.application.dto.response.CacheSeatServiceResponseDto;
-import com.boeingmerryho.business.seatservice.domain.Membership;
-import com.boeingmerryho.business.seatservice.domain.ReservationStatus;
 import com.boeingmerryho.business.seatservice.domain.service.GetCacheBlockSeatsService;
 import com.boeingmerryho.business.seatservice.domain.service.ProcessBlockSeatsService;
-import com.boeingmerryho.business.seatservice.exception.SeatErrorCode;
 import com.boeingmerryho.business.seatservice.infrastructure.helper.MembershipHelper;
 import com.boeingmerryho.business.seatservice.infrastructure.helper.SeatCommonHelper;
 
-import io.github.boeingmerryho.commonlibrary.exception.GlobalException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -45,11 +29,9 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 @RequiredArgsConstructor
 public class SeatService {
-	private final RedissonClient redissonClient;
 	private final SeatCommonHelper seatCommonHelper;
 	private final MembershipHelper membershipHelper;
-	private final KafkaTemplate<String, Object> kafkaTemplate;
-	private final RedisTemplate<String, String> redisTemplate;
+	private final KafkaProducerService kafkaProducerService;
 	private final SeatApplicationMapper seatApplicationMapper;
 	private final ProcessBlockSeatsService processBlockSeatsService;
 	private final GetCacheBlockSeatsService getCacheBlockSeatsService;
@@ -68,195 +50,25 @@ public class SeatService {
 
 	@Transactional
 	public void processBlockSeats(Long userId, CacheSeatsProcessServiceRequestDto request) {
-		if (request.serviceRequestSeatInfos().size() > 4) {
-			throw new GlobalException(SeatErrorCode.NOT_EXCEED_4_SEAT);
-		}
-
 		LocalDate today = LocalDate.now();
 
-		if (request.date().isBefore(today)) {
-			throw new GlobalException(SeatErrorCode.NOT_ACCESS_BEFORE_TODAY);
-		}
-
-		long daysBetween = ChronoUnit.DAYS.between(today, request.date());
-		if (Math.abs(daysBetween) > 7) {
-			throw new GlobalException(SeatErrorCode.NOT_OVER_1_WEEK);
-		}
-
-		String membershipKey = createMembershipKey(userId);
-		String membership = getMembership(membershipKey);
-		log.info("{}", membership);
-
-		if (request.date().isEqual(today.plusDays(7))) {
-			LocalTime now = LocalTime.now();
-
-			switch (Membership.valueOf(membership)) {
-				case NORMAL:
-					if (now.isBefore(LocalTime.of(14, 0))) {
-						throw new GlobalException(SeatErrorCode.NOT_OPEN_RESERVATION);
-					}
-
-				case SENIOR:
-					if (now.isBefore(LocalTime.of(14, 0))) {
-						throw new GlobalException(SeatErrorCode.NOT_OPEN_RESERVATION);
-					}
-
-				case GOLD:
-					if (now.isBefore(LocalTime.of(12, 0))) {
-						throw new GlobalException(SeatErrorCode.NOT_OPEN_RESERVATION);
-					}
-
-				case VIP:
-					if (now.isBefore(LocalTime.of(12, 0))) {
-						throw new GlobalException(SeatErrorCode.NOT_OPEN_RESERVATION);
-					}
-
-				case SVIP:
-					if (now.isBefore(LocalTime.of(11, 0))) {
-						throw new GlobalException(SeatErrorCode.NOT_OPEN_RESERVATION);
-					}
-			}
-		}
+		processBlockSeatsService.validateSeatReservation(userId, request, today);
 
 		ToTicketMatchDto matchInfo = processBlockSeatsService.getMatchInfo(request, today);
 
 		String cacheBlockKey = seatCommonHelper.createCacheBlockKey(request.blockId(), request.date());
-		RList<String> blockSeats = processBlockSeatsService.getBlockSeats(cacheBlockKey);
+		RSet<String> blockSeats = processBlockSeatsService.getBlocks(cacheBlockKey);
 
 		List<RLock> locks = new ArrayList<>();
 		List<String> requestSeats = new ArrayList<>();
 		List<ToTicketSeatDto> seatInfos = new ArrayList<>();
 
-		String cacheSeatKeyFront = createCacheSeatKeyFront(request.date(), request.blockId());
+		processBlockSeatsService.getBlockSeats(locks, blockSeats, requestSeats, request);
 
-		for (CacheSeatProcessServiceRequestDto requestSeat : request.serviceRequestSeatInfos()) {
-			String cacheSeatKey = createCacheSeatKey(
-				cacheSeatKeyFront,
-				requestSeat.column(),
-				requestSeat.row()
-			);
+		processBlockSeatsService.processSeatLocksAndUpdate(userId, locks, requestSeats, seatInfos);
 
-			if (!blockSeats.contains(cacheSeatKey)) {
-				log.error("블록 내 존재하지 않는 좌석 요청 : {}", cacheSeatKey);
-				throw new GlobalException(SeatErrorCode.NOT_FOUND_SEAT);
-			}
+		ToTicketDto ticketDto = seatApplicationMapper.toTicketDto(matchInfo, seatInfos);
 
-			requestSeats.add(cacheSeatKey);
-			locks.add(redissonClient.getLock(createLockKey(cacheSeatKey)));
-		}
-
-		try {
-			for (RLock lock : locks) {
-				if (!lock.tryLock(3, 10, TimeUnit.SECONDS)) {
-					log.error("⛔️ 락 획득 실패");
-					throw new GlobalException(SeatErrorCode.FAILED_GET_LOCK);
-				}
-			}
-
-			for (String requestSeat : requestSeats) {
-				RBucket<Map<String, String>> seatBucketKey = redissonClient.getBucket(requestSeat);
-				Map<String, String> seatBucketValue = seatBucketKey.get();
-
-				if (seatBucketValue == null) {
-					throw new GlobalException(SeatErrorCode.NOT_FOUND_SEAT);
-				}
-
-				String requestSeatStatus = seatBucketValue.get("status");
-				if (!requestSeatStatus.equals(ReservationStatus.AVAILABLE.name())) {
-					throw new GlobalException(SeatErrorCode.ALREADY_PROCESS_SEAT);
-				}
-
-				boolean requestSeatIsSenior = Boolean.parseBoolean(seatBucketValue.get("isSenior"));
-				if (requestSeatIsSenior) {
-					if (!membership.equals(Membership.SENIOR.name())) {
-						log.error("시니어 좌석이므로 권한이 존재하지 않습니다.");
-						throw new GlobalException(SeatErrorCode.PROCESS_ONLY_SENIOR);
-					}
-				}
-
-				seatBucketValue.put("status", ReservationStatus.PROCESSING.name());
-				seatBucketValue.put("userId", String.valueOf(userId));
-				seatBucketValue.put("createdAt", LocalDateTime.now().toString());
-				seatBucketValue.put("expiredAt", LocalDateTime.now().plusMinutes(9).toString());
-
-				seatBucketKey.set(seatBucketValue, Duration.ofMinutes(20));
-
-				ToTicketSeatDto seatInfo = parseSeatBucket(seatBucketKey.getName(), seatBucketValue);
-				seatInfos.add(seatInfo);
-
-				log.info("좌석: {}, 선점 완료", seatBucketKey.getName());
-			}
-
-			ToTicketDto ticketDto = seatApplicationMapper.toTicketDto(matchInfo, seatInfos);
-
-			kafkaTemplate.send("ticket-created", ticketDto);
-		} catch (Exception e) {
-			throw new GlobalException(SeatErrorCode.FAILED_PROCESS_SEAT);
-		} finally {
-			for (RLock lock : locks) {
-				if (lock.isHeldByCurrentThread()) {
-					lock.unlock();
-				}
-			}
-		}
-	}
-
-	private String createMembershipKey(Long userId) {
-		StringBuilder membershipKey = new StringBuilder()
-			.append("user:membership:info:")
-			.append(userId);
-
-		return membershipKey.toString();
-	}
-
-	private String getMembership(String membershipKey) {
-		Map<Object, Object> membershipInfo = redisTemplate.opsForHash().entries(membershipKey);
-		Object name = membershipInfo.get("name");
-
-		return name != null ? name.toString() : Membership.NORMAL.name();
-	}
-
-	private String createLockKey(String cacheSeatKey) {
-		StringBuilder cacheLockKey = new StringBuilder()
-			.append(cacheSeatKey)
-			.append(":lock");
-
-		return cacheLockKey.toString();
-	}
-
-	private String createCacheSeatKeyFront(LocalDate date, Integer blockId) {
-		StringBuilder keyFront = new StringBuilder()
-			.append(seatCommonHelper.seatPrefix)
-			.append(date)
-			.append(":")
-			.append(blockId)
-			.append(":");
-
-		return keyFront.toString();
-	}
-
-	private String createCacheSeatKey(String cacheSeatKeyFront, Integer column, Integer row) {
-		StringBuilder cacheSeatKey = new StringBuilder()
-			.append(cacheSeatKeyFront)
-			.append(column)
-			.append(":")
-			.append(row);
-
-		return cacheSeatKey.toString();
-	}
-
-	private ToTicketSeatDto parseSeatBucket(String seatBucketKey, Map<String, String> seatBucketValue) {
-		String[] parts = seatBucketKey.split(":");
-
-		return seatApplicationMapper.toTicketSeatDto(
-			seatBucketValue.get("id"),
-			seatBucketValue.get("userId"),
-			parts[2],
-			parts[3],
-			parts[4],
-			seatBucketValue.get("price"),
-			seatBucketValue.get("createdAt"),
-			seatBucketValue.get("expiredAt")
-		);
+		kafkaProducerService.sendTicketCreatedEvent(ticketDto);
 	}
 }

--- a/seat-service/src/main/java/com/boeingmerryho/business/seatservice/exception/MembershipErrorCode.java
+++ b/seat-service/src/main/java/com/boeingmerryho/business/seatservice/exception/MembershipErrorCode.java
@@ -1,0 +1,35 @@
+package com.boeingmerryho.business.seatservice.exception;
+
+import org.springframework.http.HttpStatus;
+
+import io.github.boeingmerryho.commonlibrary.exception.BaseErrorCode;
+
+public enum MembershipErrorCode implements BaseErrorCode {
+	INVALID_MEMBERSHIP(HttpStatus.BAD_REQUEST, "MEMBERSHIP_001", "유효하지 않은 멤버십 정보입니다."),
+	NOT_FOUND_MEMBERSHIP(HttpStatus.NOT_FOUND, "MEMBERSHIP_002", "존재하지 않는 멤버십 정보입니다.");
+
+	private final HttpStatus status;
+	private final String errorCode;
+	private final String message;
+
+	MembershipErrorCode(HttpStatus status, String errorCode, String message) {
+		this.status = status;
+		this.errorCode = errorCode;
+		this.message = message;
+	}
+
+	@Override
+	public HttpStatus getStatus() {
+		return status;
+	}
+
+	@Override
+	public String getErrorCode() {
+		return errorCode;
+	}
+
+	@Override
+	public String getMessage() {
+		return message;
+	}
+}

--- a/seat-service/src/main/java/com/boeingmerryho/business/seatservice/infrastructure/adaptor/kafka/listener/SeatFailedListener.java
+++ b/seat-service/src/main/java/com/boeingmerryho/business/seatservice/infrastructure/adaptor/kafka/listener/SeatFailedListener.java
@@ -3,7 +3,7 @@ package com.boeingmerryho.business.seatservice.infrastructure.adaptor.kafka.list
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Service;
 
-import com.boeingmerryho.business.seatservice.application.service.ListenerService;
+import com.boeingmerryho.business.seatservice.application.service.KafkaListenerService;
 import com.boeingmerryho.business.seatservice.presentation.dto.response.SeatListenerResponseDto;
 
 import io.github.boeingmerryho.commonlibrary.exception.GlobalException;
@@ -14,12 +14,12 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 @RequiredArgsConstructor
 public class SeatFailedListener {
-	private final ListenerService listenerService;
+	private final KafkaListenerService kafkaListenerService;
 
 	@KafkaListener(topics = "seat-failed", groupId = "seat-ticket")
 	public void seatFailedConsume(SeatListenerResponseDto response) {
 		try {
-			listenerService.seatFailed(response);
+			kafkaListenerService.seatFailed(response);
 		} catch (GlobalException e) {
 			log.warn("GlobalException - {}", e.getMessage());
 		}

--- a/seat-service/src/main/java/com/boeingmerryho/business/seatservice/infrastructure/adaptor/kafka/listener/SeatSucceedListener.java
+++ b/seat-service/src/main/java/com/boeingmerryho/business/seatservice/infrastructure/adaptor/kafka/listener/SeatSucceedListener.java
@@ -3,7 +3,7 @@ package com.boeingmerryho.business.seatservice.infrastructure.adaptor.kafka.list
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Service;
 
-import com.boeingmerryho.business.seatservice.application.service.ListenerService;
+import com.boeingmerryho.business.seatservice.application.service.KafkaListenerService;
 import com.boeingmerryho.business.seatservice.presentation.dto.response.SeatListenerResponseDto;
 
 import io.github.boeingmerryho.commonlibrary.exception.GlobalException;
@@ -14,12 +14,12 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 @RequiredArgsConstructor
 public class SeatSucceedListener {
-	private final ListenerService listenerService;
+	private final KafkaListenerService kafkaListenerService;
 
 	@KafkaListener(topics = "seat-succeed", groupId = "seat-ticket")
 	public void seatSucceedConsume(SeatListenerResponseDto response) {
 		try {
-			listenerService.seatSucceed(response);
+			kafkaListenerService.seatSucceed(response);
 		} catch (GlobalException e) {
 			log.warn("GlobalException - {}", e.getMessage());
 		}


### PR DESCRIPTION
## PR Type
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Summary : 변경 내용
- **as-is**
  - 좌석 선점하기 로직 수정 전

- **to-be**
  KafkaListenerService
  - 파일명 변경 (ListenerService -> KafkaListenerService)
  
  KafkaProducerService
  - Kafka 메서드 분리
  - sendEvent
  - sendTicketCreatedEvent
  
  MembershipErrorCode
  - INVALID_MEMBERSHIP
  - NOT_FOUND_MEMBERSHIP
  
  SeatService
  - processBlockSeats 메서드 내부 로직 수정
  
  ProcessBlockSeatsService
  - parseSeatBucket
  - createCacheSeatKey
  - createMembershipKey
  - getBlocks
  - updateSeatStatus
  - releaseLocks
  - acquireLocks
  - processSeatLocksAndUpdate
  - checkReservationTime
  - validateSeatReservation

## Issue Number
- close #269 

## Etc
<!-- 작업 중 특이사항이 생기면 적어주세요 -->
특이사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a service for sending Kafka events related to ticket creation and other actions.
  - Introduced specific error messages for membership-related issues.

- **Refactor**
  - Streamlined seat reservation processing by delegating validation, locking, and event sending to dedicated services.
  - Improved membership validation and time-based reservation rules.
  - Updated internal naming for listener services to clarify Kafka integration.

- **Bug Fixes**
  - Enhanced error handling for invalid or missing membership during seat reservations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->