### PR TITLE
[Membership] 메트릭 설정

### DIFF
--- a/membership-service/build.gradle
+++ b/membership-service/build.gradle
@@ -31,6 +31,7 @@ ext {
 dependencies {
     // Spring Boot starter
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
@@ -64,6 +65,7 @@ dependencies {
 
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'io.lettuce:lettuce-core'
 
     // kafka
     implementation 'org.springframework.kafka:spring-kafka'

--- a/membership-service/build.gradle
+++ b/membership-service/build.gradle
@@ -30,8 +30,9 @@ ext {
 
 dependencies {
     // Spring Boot starter
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     // Spring cloud
@@ -66,6 +67,9 @@ dependencies {
 
     // kafka
     implementation 'org.springframework.kafka:spring-kafka'
+
+    // metric
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 
     // GCP Logging
     implementation 'com.google.cloud:spring-cloud-gcp-logging:6.1.0'

--- a/membership-service/src/main/java/com/boeingmerryho/business/membershipservice/infrastructure/config/TimedConfig.java
+++ b/membership-service/src/main/java/com/boeingmerryho/business/membershipservice/infrastructure/config/TimedConfig.java
@@ -1,0 +1,15 @@
+package com.boeingmerryho.business.membershipservice.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.micrometer.core.aop.TimedAspect;
+import io.micrometer.core.instrument.MeterRegistry;
+
+@Configuration
+public class TimedConfig {
+	@Bean
+	public TimedAspect timedAspect(MeterRegistry meterRegistry) {
+		return new TimedAspect(meterRegistry);
+	}
+}

--- a/membership-service/src/main/java/com/boeingmerryho/business/membershipservice/infrastructure/config/auth/WebMvcConfig.java
+++ b/membership-service/src/main/java/com/boeingmerryho/business/membershipservice/infrastructure/config/auth/WebMvcConfig.java
@@ -21,12 +21,14 @@ public class WebMvcConfig implements WebMvcConfigurer {
 		registry.addInterceptor(new UserCheckInterceptor(userInfoProvider))
 			.excludePathPatterns(
 				"/membership-service/**",
-				"/error/**");
+				"/error/**",
+				"/actuator/**");
 
 		registry.addInterceptor(new AdminCheckInterceptor(userInfoProvider))
 			.excludePathPatterns(
 				"/api/**",
 				"/membership-service/**",
-				"/error/**");
+				"/error/**",
+				"/actuator/**");
 	}
 }

--- a/membership-service/src/main/java/com/boeingmerryho/business/membershipservice/presentation/controller/user/MembershipUserController.java
+++ b/membership-service/src/main/java/com/boeingmerryho/business/membershipservice/presentation/controller/user/MembershipUserController.java
@@ -20,6 +20,7 @@ import com.boeingmerryho.business.membershipservice.presentation.dto.response.Me
 import io.github.boeingmerryho.commonlibrary.entity.UserRoleType;
 import io.github.boeingmerryho.commonlibrary.interceptor.RequiredRoles;
 import io.github.boeingmerryho.commonlibrary.response.SuccessResponse;
+import io.micrometer.core.annotation.Timed;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -46,6 +47,7 @@ public class MembershipUserController {
 
 	@PostMapping("/{membershipId}/reserve")
 	@RequiredRoles({UserRoleType.NORMAL, UserRoleType.SENIOR})
+	@Timed(value = "membership_reserve_request", description = "멤버십 요청 처리 시간")
 	public ResponseEntity<SuccessResponse<MembershipUserCreateResponseDto>> reserveMembership(
 		@PathVariable Long membershipId,
 		@RequestAttribute Long userId

--- a/membership-service/src/main/resources/logback-spring.xml
+++ b/membership-service/src/main/resources/logback-spring.xml
@@ -11,13 +11,7 @@
         <charset>utf8</charset>
     </encoder>
 
-    <!-- springProfile: dev -->
     <springProfile name="dev">
-        <!-- Google Cloud Logging Appender -->
-        <appender name="GCP_LOGGING" class="com.google.cloud.logging.logback.LoggingAppender">
-            <log>Membership-Service</log>
-            <flushLevel>INFO</flushLevel>
-        </appender>
 
         <property name="LOG_PATH" value="./membership-service/logs/dev"/>
 
@@ -80,7 +74,6 @@
         </appender>
 
         <root level="INFO">
-            <appender-ref ref="GCP_LOGGING"/>
             <appender-ref ref="CONSOLE"/>
             <appender-ref ref="INFO_FILE"/>
             <appender-ref ref="WARN_FILE"/>
@@ -90,6 +83,11 @@
 
     <!-- springProfile: prod -->
     <springProfile name="prod">
+        <!-- Google Cloud Logging Appender -->
+        <appender name="GCP_LOGGING" class="com.google.cloud.logging.logback.LoggingAppender">
+            <log>Membership-Service</log>
+            <flushLevel>INFO</flushLevel>
+        </appender>
         <property name="LOG_PATH" value="./membership-service/logs/prod"/>
 
         <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
@@ -151,6 +149,7 @@
         </appender>
 
         <root level="INFO">
+            <appender-ref ref="GCP_LOGGING"/>
             <appender-ref ref="CONSOLE"/>
             <appender-ref ref="INFO_FILE"/>
             <appender-ref ref="WARN_FILE"/>

--- a/store-service/src/main/resources/logback-spring.xml
+++ b/store-service/src/main/resources/logback-spring.xml
@@ -11,13 +11,7 @@
         <charset>utf8</charset>
     </encoder>
 
-    <!-- springProfile: dev -->
     <springProfile name="dev">
-        <!-- Google Cloud Logging Appender -->
-        <appender name="GCP_LOGGING" class="com.google.cloud.logging.logback.LoggingAppender">
-            <log>Store-Service</log>
-            <flushLevel>INFO</flushLevel>
-        </appender>
 
         <property name="LOG_PATH" value="./store-service/logs/dev"/>
 
@@ -80,7 +74,6 @@
         </appender>
 
         <root level="INFO">
-            <appender-ref ref="GCP_LOGGING"/>
             <appender-ref ref="CONSOLE"/>
             <appender-ref ref="INFO_FILE"/>
             <appender-ref ref="WARN_FILE"/>
@@ -90,6 +83,12 @@
 
     <!-- springProfile: prod -->
     <springProfile name="prod">
+
+        <appender name="GCP_LOGGING" class="com.google.cloud.logging.logback.LoggingAppender">
+            <log>Store-Service</log>
+            <flushLevel>INFO</flushLevel>
+        </appender>
+
         <property name="LOG_PATH" value="./store-service/logs/prod"/>
 
         <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
@@ -151,6 +150,7 @@
         </appender>
 
         <root level="INFO">
+            <appender-ref ref="GCP_LOGGING"/>
             <appender-ref ref="CONSOLE"/>
             <appender-ref ref="INFO_FILE"/>
             <appender-ref ref="WARN_FILE"/>


### PR DESCRIPTION
## PR Type
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Summary : 변경 내용
- **as-is**
  - logback dev, prod 에 따른 gcp logging 설정 반대로 됨

- **to-be**
  - logback dev, prod 에 따른 gcp logging 설정 정상화
  - membership metrics 설정

## Issue Number
- close #287 

## Etc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added application monitoring and metrics collection, including support for Prometheus and method-level timing with Micrometer.
	- Introduced aspect-oriented programming and enhanced Redis support.

- **Improvements**
	- Membership reservation failures are now tracked with detailed metrics for better observability.
	- The membership reservation endpoint now records request processing time for performance monitoring.

- **Bug Fixes**
	- Requests to "/actuator/**" are now excluded from user and admin authentication checks.

- **Chores**
	- Google Cloud Logging is now enabled only in production environments for both membership and store services, and disabled in development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->