### PR TITLE
[Membership] 멤버십 선점 리팩토링

### DIFF
--- a/membership-service/src/main/java/com/boeingmerryho/business/membershipservice/application/service/kafka/ListenerService.java
+++ b/membership-service/src/main/java/com/boeingmerryho/business/membershipservice/application/service/kafka/ListenerService.java
@@ -18,7 +18,7 @@ public class ListenerService {
 
 	@Transactional
 	public void paymentSucceed(MembershipPaymentEvent response) {
-		membershipListenerHelper.handleMembershipSuccess(response.userId());
+		membershipListenerHelper.handleMembershipSuccess(response.userId(), response.membershipId());
 	}
 
 	public void paymentFailure(MembershipPaymentEvent response) {

--- a/membership-service/src/main/java/com/boeingmerryho/business/membershipservice/infrastructure/config/KafkaConsumerConfig.java
+++ b/membership-service/src/main/java/com/boeingmerryho/business/membershipservice/infrastructure/config/KafkaConsumerConfig.java
@@ -26,16 +26,15 @@ public class KafkaConsumerConfig {
 		props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
 		props.put(ConsumerConfig.GROUP_ID_CONFIG, "membership-service");
 		props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-		props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-		props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
-		props.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
-		props.put(JsonDeserializer.VALUE_DEFAULT_TYPE, MembershipPaymentEvent.class);
-		props.put(JsonDeserializer.USE_TYPE_INFO_HEADERS, false);
 
-		return new DefaultKafkaConsumerFactory<>(props);
+		return new DefaultKafkaConsumerFactory<>(
+			props,
+			new StringDeserializer(),
+			new JsonDeserializer<>(MembershipPaymentEvent.class, false)
+		);
 	}
 
-	@Bean(name = "paymentKafkaListenerContainerFactory")
+	@Bean
 	public ConcurrentKafkaListenerContainerFactory<String, MembershipPaymentEvent> paymentKafkaListenerContainerFactory() {
 		ConcurrentKafkaListenerContainerFactory<String, MembershipPaymentEvent> factory =
 			new ConcurrentKafkaListenerContainerFactory<>();
@@ -54,7 +53,7 @@ public class KafkaConsumerConfig {
 		return new DefaultKafkaConsumerFactory<>(props);
 	}
 
-	@Bean(name = "rollbackKafkaListenerContainerFactory")
+	@Bean
 	public ConcurrentKafkaListenerContainerFactory<String, String> rollbackKafkaListenerContainerFactory() {
 		ConcurrentKafkaListenerContainerFactory<String, String> factory =
 			new ConcurrentKafkaListenerContainerFactory<>();

--- a/membership-service/src/main/java/com/boeingmerryho/business/membershipservice/infrastructure/config/KafkaConsumerConfig.java
+++ b/membership-service/src/main/java/com/boeingmerryho/business/membershipservice/infrastructure/config/KafkaConsumerConfig.java
@@ -1,0 +1,64 @@
+package com.boeingmerryho.business.membershipservice.infrastructure.config;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+import com.boeingmerryho.business.membershipservice.application.dto.kafka.MembershipPaymentEvent;
+
+@Configuration
+public class KafkaConsumerConfig {
+	@Value("${spring.kafka.bootstrap-servers}")
+	private String bootstrapServers;
+
+	@Bean
+	public ConsumerFactory<String, MembershipPaymentEvent> paymentConsumerFactory() {
+		Map<String, Object> props = new HashMap<>();
+		props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+		props.put(ConsumerConfig.GROUP_ID_CONFIG, "membership-service");
+		props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+		props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+		props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+		props.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+		props.put(JsonDeserializer.VALUE_DEFAULT_TYPE, MembershipPaymentEvent.class);
+		props.put(JsonDeserializer.USE_TYPE_INFO_HEADERS, false);
+
+		return new DefaultKafkaConsumerFactory<>(props);
+	}
+
+	@Bean(name = "paymentKafkaListenerContainerFactory")
+	public ConcurrentKafkaListenerContainerFactory<String, MembershipPaymentEvent> paymentKafkaListenerContainerFactory() {
+		ConcurrentKafkaListenerContainerFactory<String, MembershipPaymentEvent> factory =
+			new ConcurrentKafkaListenerContainerFactory<>();
+		factory.setConsumerFactory(paymentConsumerFactory());
+		return factory;
+	}
+
+	@Bean
+	public ConsumerFactory<String, String> rollbackConsumerFactory() {
+		Map<String, Object> props = new HashMap<>();
+		props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+		props.put(ConsumerConfig.GROUP_ID_CONFIG, "membership-rollback-group");
+		props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+		props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+		props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+		return new DefaultKafkaConsumerFactory<>(props);
+	}
+
+	@Bean(name = "rollbackKafkaListenerContainerFactory")
+	public ConcurrentKafkaListenerContainerFactory<String, String> rollbackKafkaListenerContainerFactory() {
+		ConcurrentKafkaListenerContainerFactory<String, String> factory =
+			new ConcurrentKafkaListenerContainerFactory<>();
+		factory.setConsumerFactory(rollbackConsumerFactory());
+		return factory;
+	}
+}

--- a/membership-service/src/main/java/com/boeingmerryho/business/membershipservice/infrastructure/config/RedisConfig.java
+++ b/membership-service/src/main/java/com/boeingmerryho/business/membershipservice/infrastructure/config/RedisConfig.java
@@ -4,6 +4,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
@@ -35,6 +36,13 @@ public class RedisConfig {
 		template.setHashValueSerializer(serializer);
 		template.afterPropertiesSet();
 		return template;
+	}
+
+	@Bean
+	public RedisMessageListenerContainer redisMessageListenerContainer(RedisConnectionFactory connectionFactory) {
+		RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+		container.setConnectionFactory(connectionFactory);
+		return container;
 	}
 }
 

--- a/membership-service/src/main/java/com/boeingmerryho/business/membershipservice/infrastructure/helper/MembershipRedisHelper.java
+++ b/membership-service/src/main/java/com/boeingmerryho/business/membershipservice/infrastructure/helper/MembershipRedisHelper.java
@@ -41,7 +41,7 @@ public class MembershipRedisHelper {
 		
 			redis.call("SADD", KEYS[2], ARGV[1])
 			redis.call("SET", ARGV[2], 1, "EX", tonumber(ARGV[3]))
-		 	redis.call("SET", ARGV[4], ARGV[5], "EX", tonumber(ARGV[3]))
+		 	redis.call("SET", ARGV[4], ARGV[5])
 			return 1
 		""";
 	// TODO redis command 각각 쪼개기 방법이랑 비교

--- a/membership-service/src/main/java/com/boeingmerryho/business/membershipservice/infrastructure/kafka/consumer/MembershipRollbackConsumer.java
+++ b/membership-service/src/main/java/com/boeingmerryho/business/membershipservice/infrastructure/kafka/consumer/MembershipRollbackConsumer.java
@@ -16,6 +16,7 @@ public class MembershipRollbackConsumer {
 
 	private static final String STOCK_PREFIX = "membership:stock:";
 	private static final String USERS_PREFIX = "membership:users:";
+	private static final String MEMBERSHIP_ROLLBACK_ID_PREFIX = "membership:user:map:";
 
 	@KafkaListener(
 		topics = "membership.reserve.rollback",
@@ -35,9 +36,11 @@ public class MembershipRollbackConsumer {
 
 			String stockKey = STOCK_PREFIX + membershipId;
 			String userSetKey = USERS_PREFIX + membershipId;
+			String mapKey = MEMBERSHIP_ROLLBACK_ID_PREFIX + userId;
 
 			redisTemplate.opsForValue().increment(stockKey);
 			redisTemplate.opsForSet().remove(userSetKey, userId);
+			redisTemplate.delete(mapKey);
 
 			log.info("Rollback success: membershipId={}, userId={}", membershipId, userId);
 		} catch (Exception e) {

--- a/membership-service/src/main/java/com/boeingmerryho/business/membershipservice/infrastructure/kafka/consumer/MembershipRollbackConsumer.java
+++ b/membership-service/src/main/java/com/boeingmerryho/business/membershipservice/infrastructure/kafka/consumer/MembershipRollbackConsumer.java
@@ -1,0 +1,47 @@
+package com.boeingmerryho.business.membershipservice.infrastructure.kafka.consumer;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MembershipRollbackConsumer {
+
+	private final RedisTemplate<String, String> redisTemplate;
+
+	private static final String STOCK_PREFIX = "membership:stock:";
+	private static final String USERS_PREFIX = "membership:users:";
+
+	@KafkaListener(
+		topics = "membership.reserve.rollback",
+		groupId = "membership-rollback-group",
+		containerFactory = "rollbackKafkaListenerContainerFactory"
+	)
+	public void consume(String message) {
+		try {
+			String[] parts = message.split(":");
+			if (parts.length != 2) {
+				log.warn("Invalid rollback message format: {}", message);
+				return;
+			}
+
+			String membershipId = parts[0];
+			String userId = parts[1];
+
+			String stockKey = STOCK_PREFIX + membershipId;
+			String userSetKey = USERS_PREFIX + membershipId;
+
+			redisTemplate.opsForValue().increment(stockKey);
+			redisTemplate.opsForSet().remove(userSetKey, userId);
+
+			log.info("Rollback success: membershipId={}, userId={}", membershipId, userId);
+		} catch (Exception e) {
+			log.error("Failed to process rollback message: {}", message, e);
+		}
+	}
+}

--- a/membership-service/src/main/java/com/boeingmerryho/business/membershipservice/infrastructure/kafka/listener/PaymentSuccessKafkaListener.java
+++ b/membership-service/src/main/java/com/boeingmerryho/business/membershipservice/infrastructure/kafka/listener/PaymentSuccessKafkaListener.java
@@ -17,7 +17,11 @@ public class PaymentSuccessKafkaListener {
 
 	private final ListenerService listenerService;
 
-	@KafkaListener(topics = "payment-membership-process", groupId = "membership-service")
+	@KafkaListener(
+		topics = "payment-membership-process",
+		groupId = "membership-service",
+		containerFactory = "paymentKafkaListenerContainerFactory"
+	)
 	public void membershipSucceed(MembershipPaymentEvent response) {
 		try {
 			switch (response.event()) {

--- a/membership-service/src/main/java/com/boeingmerryho/business/membershipservice/infrastructure/kafka/listener/RedisExpirationListener.java
+++ b/membership-service/src/main/java/com/boeingmerryho/business/membershipservice/infrastructure/kafka/listener/RedisExpirationListener.java
@@ -1,0 +1,52 @@
+package com.boeingmerryho.business.membershipservice.infrastructure.kafka.listener;
+
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.KeyExpirationEventMessageListener;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class RedisExpirationListener extends KeyExpirationEventMessageListener {
+
+	private final RedisTemplate<String, String> redisTemplate;
+	private final KafkaTemplate<String, String> kafkaTemplate;
+
+	private static final String TTL_PREFIX = "membership:ttl:";
+	private static final String MAP_PREFIX = "membership:user:map:";
+	private static final String TOPIC = "membership.reserve.rollback";
+
+	public RedisExpirationListener(RedisMessageListenerContainer container,
+		RedisTemplate<String, String> redisTemplate,
+		KafkaTemplate<String, String> kafkaTemplate) {
+		super(container);
+		this.redisTemplate = redisTemplate;
+		this.kafkaTemplate = kafkaTemplate;
+	}
+
+	@Override
+	public void onMessage(Message message, byte[] pattern) {
+		String expiredKey = message.toString();
+
+		if (!expiredKey.startsWith(TTL_PREFIX))
+			return;
+
+		String userId = expiredKey.replace(TTL_PREFIX, "");
+		String mapKey = MAP_PREFIX + userId;
+
+		String membershipId = redisTemplate.opsForValue().get(mapKey);
+
+		if (membershipId != null) {
+			String payload = membershipId + ":" + userId;
+			kafkaTemplate.send(TOPIC, payload);
+			log.info("Published rollback event to Kafka: {}", payload);
+		} else {
+			log.warn("Rollback target not found for expired userId={}", userId);
+		}
+	}
+}
+


### PR DESCRIPTION
## PR Type
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Summary : 변경 내용
- **as-is**
  - 멤버십 선점 userId 기반 문자열 키 관리

- **to-be**
  - 멤버십 선점 SET 키 관리
  - ttl 개별 관리 및 expired event listener 구현 및 kafka 메시징 적용
  - ttl 만료시 멤버십 재고 롤백
  - 결제 성공 시 이벤트 처리 수정

## Issue Number
- close #236 

## Etc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for handling membership reservation rollbacks via Kafka and Redis key expiration events.
  - Introduced new listeners for Kafka rollback messages and Redis key expirations to manage membership state and cleanup.
  - Enabled Redis message listening capabilities within the application.

- **Improvements**
  - Enhanced Redis key management by using sets for user memberships, adding TTL keys, and introducing rollback mapping.
  - Updated Kafka listener configuration for more explicit consumer factory usage.
  - Improved internal handling of membership success and rollback scenarios for better reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->